### PR TITLE
Restore support for html language

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 				"path": "./syntaxes/injection.json",
 				"scopeName": "html.alpinejs.attribute",
 				"injectTo": [
-					"text.html.derivative", 
+					"text.html", 
 					"text.html.php", 
 					"text.html.twig"
 				],

--- a/syntaxes/injection.json
+++ b/syntaxes/injection.json
@@ -1,6 +1,6 @@
 {
     "scopeName": "html.alpinejs.attribute",
-    "injectionSelector": ["L:text.html.derivative", "L:text.html.php", "L:text.html.twig"],
+    "injectionSelector": ["L:text.html", "L:text.html.php", "L:text.html.twig"],
     "patterns": [
         {
             "include": "#alpine-directives"


### PR DESCRIPTION
Something must have changed in VS Code and syntax highlighting was not working on HTML files anymore. Removing ".derivative" seems to restore syntax highlighting.